### PR TITLE
Update libmanette to 0.2.6

### DIFF
--- a/org.gnome.Quadrapassel.json
+++ b/org.gnome.Quadrapassel.json
@@ -63,9 +63,9 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://gitlab.gnome.org/aplazas/libmanette.git",
-          "tag": "0.2.5",
-          "commit": "77d2c2c9fab2a8e08aead23f3ea059ad5d38f005"
+          "url": "https://gitlab.gnome.org/GNOME/libmanette.git",
+          "tag": "0.2.6",
+          "commit": "f3fc99a3582845725dc3f56fe7ffdc1ae3019d0f"
         }
       ]
     },


### PR DESCRIPTION
This also fixes its URL as the project moved to the GNOME group.