### PR TITLE
Update quadrapassel runtime to 46

### DIFF
--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -1,0 +1,29 @@
+From c5ab89dea38b09538f18683a07c3772d59cd8151 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Sun, 28 Jul 2024 13:45:42 +0300
+Subject: [PATCH] Fix appdata papercuts
+
+- Add vcs-browser URL to show the source code repository
+- Add translate URL to show the translation repository
+- Add missing launchable tag
+---
+ data/org.gnome.Quadrapassel.appdata.xml.in | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/data/org.gnome.Quadrapassel.appdata.xml.in b/data/org.gnome.Quadrapassel.appdata.xml.in
+index b320225..a233cbd 100644
+--- a/data/org.gnome.Quadrapassel.appdata.xml.in
++++ b/data/org.gnome.Quadrapassel.appdata.xml.in
+@@ -30,6 +30,9 @@
+   <url type="bugtracker">https://gitlab.gnome.org/GNOME/quadrapassel/issues</url>
+   <url type="donation">http://www.gnome.org/friends/</url>
+   <url type="help">https://help.gnome.org/users/quadrapassel/stable/</url>
++  <url type="vcs-browser">https://gitlab.gnome.org/GNOME/quadrapassel</url>
++  <url type="translate">https://l10n.gnome.org/module/quadrapassel/</url>
++  <launchable type="desktop-id">org.gnome.Quadrapassel.desktop</launchable>
+   <developer_name>The GNOME Project</developer_name>
+   <releases>
+     <release date="2021-06-10" version="40.2" />
+--
+libgit2 1.7.2
+

--- a/org.gnome.Quadrapassel.json
+++ b/org.gnome.Quadrapassel.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.Quadrapassel",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "45",
+  "runtime-version": "46",
   "sdk": "org.gnome.Sdk",
   "command": "quadrapassel",
   "finish-args": [

--- a/org.gnome.Quadrapassel.json
+++ b/org.gnome.Quadrapassel.json
@@ -73,6 +73,10 @@
           "type": "archive",
           "url": "https://download.gnome.org/sources/quadrapassel/40/quadrapassel-40.2.tar.xz",
           "sha256": "0bd822414207c73123ed6a49f723da5ac8dd4df5d35edc099ffea2e1399cc00a"
+        },
+        {
+          "type": "patch",
+          "path": "fix-appdata.patch"
         }
       ]
     }

--- a/org.gnome.Quadrapassel.json
+++ b/org.gnome.Quadrapassel.json
@@ -5,17 +5,26 @@
   "sdk": "org.gnome.Sdk",
   "command": "quadrapassel",
   "finish-args": [
-    "--share=ipc", "--socket=fallback-x11",
+    "--share=ipc",
+    "--socket=fallback-x11",
     "--socket=wayland",
-    "--device=dri", "--socket=pulseaudio"
+    "--device=dri",
+    "--socket=pulseaudio"
   ],
   "cleanup": [
-    "/include", "/lib/pkgconfig",
-    "/share/pkgconfig", "/share/aclocal",
-    "/man", "/share/man", "/share/gtk-doc",
-    "*.la", "*.a",
+    "/include",
+    "/lib/pkgconfig",
+    "/share/pkgconfig",
+    "/share/aclocal",
+    "/man",
+    "/share/man",
+    "/share/gtk-doc",
+    "*.la",
+    "*.a",
     "/lib/girepository-1.0",
-    "/share/dbus-1", "/share/doc", "/share/gir-1.0"
+    "/share/dbus-1",
+    "/share/doc",
+    "/share/gir-1.0"
   ],
   "modules": [
     {


### PR DESCRIPTION
- Update quadrapassel runtime to 46 because runtime 45 will be EOL on 2024-09-14.
- Reorder finish-args and cleanup entries